### PR TITLE
Allow custom CSV path for import

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -53,9 +53,19 @@ class Program
 
     static void ImportCsv()
     {
+        Console.Write("CSV file path (default ./sample_import.csv): ");
+        var path = Console.ReadLine();
+        if (string.IsNullOrWhiteSpace(path))
+            path = "./sample_import.csv";
+        if (!File.Exists(path))
+        {
+            Console.WriteLine("File not found.\n");
+            return;
+        }
+
         int count = 0;
-        using var reader = new StreamReader("./sample_import.csv");
-        
+        using var reader = new StreamReader(path);
+
         string? header = reader.ReadLine();
         if (header == null) { Console.WriteLine("CSV is empty.\n"); return; }
         
@@ -80,7 +90,7 @@ class Program
             count++;
         }
         
-        Logger.Log($"CSVImport: Imported {count} reports from ./sample_import.csv");
+        Logger.Log($"CSVImport: Imported {count} reports from {path}");
     }
 
     static void ShowSecretCode()

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Malshinon is a simulated intelligence platform for collecting and analyzing comm
 
 ## Usage
 - **Submit Report**: Follow CLI prompts to log in, select target, and submit a report.
-- **Import CSV**: Use the import option and provide a CSV file (see `sample_import.csv`).
-- **Dashboard**: View analytics and alerts.
+ - **Import CSV**: Use the import option, then enter a path to a CSV file or press Enter to use `./sample_import.csv`.
+ - **Dashboard**: View analytics and alerts.
 
 ## Analysis Logic
 - **Potential Recruits**: ≥10 reports, avg. report length ≥100 chars.


### PR DESCRIPTION
## Summary
- prompt for CSV path when importing reports with default `sample_import.csv`
- document CSV import path option in README

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68beb3457f7083269b2ae1c2bd07bc32